### PR TITLE
feat: add tabs components

### DIFF
--- a/src/components/tabs/Tab01.vue
+++ b/src/components/tabs/Tab01.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+</script>
+
+<template>
+  <Tabs default-value="tab-1" class="items-center">
+    <TabsList>
+      <TabsTrigger value="tab-1">Tab 1</TabsTrigger>
+      <TabsTrigger value="tab-2">Tab 2</TabsTrigger>
+      <TabsTrigger value="tab-3">Tab 3</TabsTrigger>
+    </TabsList>
+
+    <TabsContent value="tab-1">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 1</p>
+    </TabsContent>
+
+    <TabsContent value="tab-2">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 2</p>
+    </TabsContent>
+
+    <TabsContent value="tab-3">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 3</p>
+    </TabsContent>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab02.vue
+++ b/src/components/tabs/Tab02.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+</script>
+
+<template>
+  <Tabs default-value="tab-1" class="items-center">
+    <TabsList class="bg-transparent">
+      <TabsTrigger
+        value="tab-1"
+        class="data-[state=active]:bg-muted data-[state=active]:shadow-none"
+      >
+        Tab 1
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-2"
+        class="data-[state=active]:bg-muted data-[state=active]:shadow-none"
+      >
+        Tab 2
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-3"
+        class="data-[state=active]:bg-muted data-[state=active]:shadow-none"
+      >
+        Tab 3
+      </TabsTrigger>
+    </TabsList>
+    <TabsContent value="tab-1">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 1</p>
+    </TabsContent>
+    <TabsContent value="tab-2">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 2</p>
+    </TabsContent>
+    <TabsContent value="tab-3">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 3</p>
+    </TabsContent>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab03.vue
+++ b/src/components/tabs/Tab03.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+</script>
+
+<template>
+  <Tabs defaultValue="tab-1" class="items-center">
+    <TabsList class="gap-1 bg-transparent">
+      <TabsTrigger
+        value="tab-1"
+        class="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground rounded-full data-[state=active]:shadow-none"
+      >
+        Tab 1
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-2"
+        class="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground rounded-full data-[state=active]:shadow-none"
+      >
+        Tab 2
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-3"
+        class="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground rounded-full data-[state=active]:shadow-none"
+      >
+        Tab 3
+      </TabsTrigger>
+    </TabsList>
+    <TabsContent value="tab-1">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 1</p>
+    </TabsContent>
+    <TabsContent value="tab-2">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 2</p>
+    </TabsContent>
+    <TabsContent value="tab-3">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 3</p>
+    </TabsContent>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab04.vue
+++ b/src/components/tabs/Tab04.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+</script>
+
+<template>
+  <Tabs defaultValue="tab-1" class="items-center">
+    <TabsList class="h-auto rounded-none border-b bg-transparent p-0">
+      <TabsTrigger
+        value="tab-1"
+        class="data-[state=active]:after:bg-primary relative rounded-none py-2 after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+      >
+        Tab 1
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-2"
+        class="data-[state=active]:after:bg-primary relative rounded-none py-2 after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+      >
+        Tab 2
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-3"
+        class="data-[state=active]:after:bg-primary relative rounded-none py-2 after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+      >
+        Tab 3
+      </TabsTrigger>
+    </TabsList>
+    <TabsContent value="tab-1">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 1</p>
+    </TabsContent>
+    <TabsContent value="tab-2">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 2</p>
+    </TabsContent>
+    <TabsContent value="tab-3">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 3</p>
+    </TabsContent>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab05.vue
+++ b/src/components/tabs/Tab05.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+</script>
+
+<template>
+  <Tabs defaultValue="tab-1" class="items-center">
+    <TabsList class="text-foreground h-auto gap-2 rounded-none border-b bg-transparent px-0 py-1">
+      <TabsTrigger
+        value="tab-1"
+        class="hover:bg-accent hover:text-foreground data-[state=active]:after:bg-primary data-[state=active]:hover:bg-accent relative after:absolute after:inset-x-0 after:bottom-0 after:-mb-1 after:h-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+      >
+        Tab 1
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-2"
+        class="hover:bg-accent hover:text-foreground data-[state=active]:after:bg-primary data-[state=active]:hover:bg-accent relative after:absolute after:inset-x-0 after:bottom-0 after:-mb-1 after:h-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+      >
+        Tab 2
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-3"
+        class="hover:bg-accent hover:text-foreground data-[state=active]:after:bg-primary data-[state=active]:hover:bg-accent relative after:absolute after:inset-x-0 after:bottom-0 after:-mb-1 after:h-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+      >
+        Tab 3
+      </TabsTrigger>
+    </TabsList>
+    <TabsContent value="tab-1">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 1</p>
+    </TabsContent>
+    <TabsContent value="tab-2">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 2</p>
+    </TabsContent>
+    <TabsContent value="tab-3">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 3</p>
+    </TabsContent>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab06.vue
+++ b/src/components/tabs/Tab06.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+</script>
+
+<template>
+  <Tabs defaultValue="tab-1" class="items-center">
+    <TabsList class="bg-background h-auto -space-x-px p-0 shadow-xs rtl:space-x-reverse">
+      <TabsTrigger
+        value="tab-1"
+        class="data-[state=active]:bg-muted data-[state=active]:after:bg-primary relative overflow-hidden rounded-none border py-2 after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 first:rounded-s last:rounded-e"
+      >
+        Tab 1
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-2"
+        class="data-[state=active]:bg-muted data-[state=active]:after:bg-primary relative overflow-hidden rounded-none border py-2 after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 first:rounded-s last:rounded-e"
+      >
+        Tab 2
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-3"
+        class="data-[state=active]:bg-muted data-[state=active]:after:bg-primary relative overflow-hidden rounded-none border py-2 after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 first:rounded-s last:rounded-e"
+      >
+        Tab 3
+      </TabsTrigger>
+    </TabsList>
+    <TabsContent value="tab-1">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 1</p>
+    </TabsContent>
+    <TabsContent value="tab-2">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 2</p>
+    </TabsContent>
+    <TabsContent value="tab-3">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 3</p>
+    </TabsContent>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab07.vue
+++ b/src/components/tabs/Tab07.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+</script>
+
+<template>
+  <Tabs defaultValue="tab-1">
+    <TabsList
+      class="before:bg-border relative h-auto w-full gap-0.5 bg-transparent p-0 before:absolute before:inset-x-0 before:bottom-0 before:h-px"
+    >
+      <TabsTrigger
+        value="tab-1"
+        class="bg-muted overflow-hidden rounded-b-none border-x border-t py-2 data-[state=active]:z-10 data-[state=active]:shadow-none"
+      >
+        Tab 1
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-2"
+        class="bg-muted overflow-hidden rounded-b-none border-x border-t py-2 data-[state=active]:z-10 data-[state=active]:shadow-none"
+      >
+        Tab 2
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-3"
+        class="bg-muted overflow-hidden rounded-b-none border-x border-t py-2 data-[state=active]:z-10 data-[state=active]:shadow-none"
+      >
+        Tab 3
+      </TabsTrigger>
+    </TabsList>
+    <TabsContent value="tab-1">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 1</p>
+    </TabsContent>
+    <TabsContent value="tab-2">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 2</p>
+    </TabsContent>
+    <TabsContent value="tab-3">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 3</p>
+    </TabsContent>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab08.vue
+++ b/src/components/tabs/Tab08.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+import ScrollArea from '@/components/ui/Scroll/ScrollArea.vue'
+import ScrollBar from '@/components/ui/Scroll/ScrollBar.vue'
+import { BoxIcon, HouseIcon, PanelsTopLeftIcon } from 'lucide-vue-next'
+import Badge from '@/components/ui/Badge.vue'
+</script>
+
+<template>
+  <Tabs defaultValue="tab-1">
+    <ScrollArea>
+      <TabsList class="mb-3">
+        <TabsTrigger value="tab-1">
+          <HouseIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+          Overview
+        </TabsTrigger>
+        <TabsTrigger value="tab-2" class="group">
+          <PanelsTopLeftIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+          Projects
+          <Badge
+            class="bg-primary/15 ms-1.5 min-w-5 px-1 transition-opacity group-data-[state=inactive]:opacity-50"
+            variant="secondary"
+          >
+            3
+          </Badge>
+        </TabsTrigger>
+        <TabsTrigger value="tab-3" class="group">
+          <BoxIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+          Packages
+          <Badge class="ms-1.5 transition-opacity group-data-[state=inactive]:opacity-50">
+            New
+          </Badge>
+        </TabsTrigger>
+      </TabsList>
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+    <TabsContent value="tab-1">
+      <p class="text-muted-foreground p-4 pt-1 text-center text-xs">Content for Tab 1</p>
+    </TabsContent>
+    <TabsContent value="tab-2">
+      <p class="text-muted-foreground p-4 pt-1 text-center text-xs">Content for Tab 2</p>
+    </TabsContent>
+    <TabsContent value="tab-3">
+      <p class="text-muted-foreground p-4 pt-1 text-center text-xs">Content for Tab 3</p>
+    </TabsContent>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab09.vue
+++ b/src/components/tabs/Tab09.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+import ScrollArea from '@/components/ui/Scroll/ScrollArea.vue'
+import ScrollBar from '@/components/ui/Scroll/ScrollBar.vue'
+import { BoxIcon, HouseIcon, PanelsTopLeftIcon } from 'lucide-vue-next'
+</script>
+
+<template>
+  <Tabs defaultValue="tab-1">
+    <ScrollArea>
+      <TabsList class="mb-3 gap-1 bg-transparent">
+        <TabsTrigger
+          value="tab-1"
+          class="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground rounded-full data-[state=active]:shadow-none"
+        >
+          <HouseIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+          Overview
+        </TabsTrigger>
+        <TabsTrigger
+          value="tab-2"
+          class="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground rounded-full data-[state=active]:shadow-none"
+        >
+          <PanelsTopLeftIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+          Projects
+        </TabsTrigger>
+        <TabsTrigger
+          value="tab-3"
+          class="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground rounded-full data-[state=active]:shadow-none"
+        >
+          <BoxIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+          Packages
+        </TabsTrigger>
+      </TabsList>
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+    <TabsContent value="tab-1">
+      <p class="text-muted-foreground p-4 pt-1 text-center text-xs">Content for Tab 1</p>
+    </TabsContent>
+    <TabsContent value="tab-2">
+      <p class="text-muted-foreground p-4 pt-1 text-center text-xs">Content for Tab 2</p>
+    </TabsContent>
+    <TabsContent value="tab-3">
+      <p class="text-muted-foreground p-4 pt-1 text-center text-xs">Content for Tab 3</p>
+    </TabsContent>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab10.vue
+++ b/src/components/tabs/Tab10.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+import ScrollArea from '@/components/ui/Scroll/ScrollArea.vue'
+import ScrollBar from '@/components/ui/Scroll/ScrollBar.vue'
+import { BoxIcon, HouseIcon, PanelsTopLeftIcon } from 'lucide-vue-next'
+</script>
+
+<template>
+  <Tabs defaultValue="tab-1">
+    <ScrollArea>
+      <TabsList class="bg-background mb-3 h-auto -space-x-px p-0 shadow-xs rtl:space-x-reverse">
+        <TabsTrigger
+          value="tab-1"
+          class="data-[state=active]:bg-muted data-[state=active]:after:bg-primary relative overflow-hidden rounded-none border py-2 after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 first:rounded-s last:rounded-e"
+        >
+          <HouseIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+          Overview
+        </TabsTrigger>
+        <TabsTrigger
+          value="tab-2"
+          class="data-[state=active]:bg-muted data-[state=active]:after:bg-primary relative overflow-hidden rounded-none border py-2 after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 first:rounded-s last:rounded-e"
+        >
+          <PanelsTopLeftIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+          Projects
+        </TabsTrigger>
+        <TabsTrigger
+          value="tab-3"
+          class="data-[state=active]:bg-muted data-[state=active]:after:bg-primary relative overflow-hidden rounded-none border py-2 after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 first:rounded-s last:rounded-e"
+        >
+          <BoxIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+          Packages
+        </TabsTrigger>
+      </TabsList>
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+    <TabsContent value="tab-1">
+      <p class="text-muted-foreground p-4 pt-1 text-center text-xs">Content for Tab 1</p>
+    </TabsContent>
+    <TabsContent value="tab-2">
+      <p class="text-muted-foreground p-4 pt-1 text-center text-xs">Content for Tab 2</p>
+    </TabsContent>
+    <TabsContent value="tab-3">
+      <p class="text-muted-foreground p-4 pt-1 text-center text-xs">Content for Tab 3</p>
+    </TabsContent>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab11.vue
+++ b/src/components/tabs/Tab11.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+import ScrollArea from '@/components/ui/Scroll/ScrollArea.vue'
+import ScrollBar from '@/components/ui/Scroll/ScrollBar.vue'
+import { BoxIcon, HouseIcon, PanelsTopLeftIcon } from 'lucide-vue-next'
+</script>
+
+<template>
+  <Tabs defaultValue="tab-1">
+    <ScrollArea>
+      <TabsList
+        class="before:bg-border relative mb-3 h-auto w-full gap-0.5 bg-transparent p-0 before:absolute before:inset-x-0 before:bottom-0 before:h-px"
+      >
+        <TabsTrigger
+          value="tab-1"
+          class="bg-muted overflow-hidden rounded-b-none border-x border-t py-2 data-[state=active]:z-10 data-[state=active]:shadow-none"
+        >
+          <HouseIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+          Overview
+        </TabsTrigger>
+        <TabsTrigger
+          value="tab-2"
+          class="bg-muted overflow-hidden rounded-b-none border-x border-t py-2 data-[state=active]:z-10 data-[state=active]:shadow-none"
+        >
+          <PanelsTopLeftIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+          Projects
+        </TabsTrigger>
+        <TabsTrigger
+          value="tab-3"
+          class="bg-muted overflow-hidden rounded-b-none border-x border-t py-2 data-[state=active]:z-10 data-[state=active]:shadow-none"
+        >
+          <BoxIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+          Packages
+        </TabsTrigger>
+      </TabsList>
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+    <TabsContent value="tab-1">
+      <p class="text-muted-foreground p-4 pt-1 text-center text-xs">Content for Tab 1</p>
+    </TabsContent>
+    <TabsContent value="tab-2">
+      <p class="text-muted-foreground p-4 pt-1 text-center text-xs">Content for Tab 2</p>
+    </TabsContent>
+    <TabsContent value="tab-3">
+      <p class="text-muted-foreground p-4 pt-1 text-center text-xs">Content for Tab 3</p>
+    </TabsContent>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab12.vue
+++ b/src/components/tabs/Tab12.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+import ScrollArea from '@/components/ui/Scroll/ScrollArea.vue'
+import ScrollBar from '@/components/ui/Scroll/ScrollBar.vue'
+import {
+  BoxIcon,
+  ChartLine,
+  HouseIcon,
+  PanelsTopLeftIcon,
+  SettingsIcon,
+  UsersRoundIcon
+} from 'lucide-vue-next'
+import Badge from '@/components/ui/Badge.vue'
+</script>
+
+<template>
+  <Tabs defaultValue="tab-1">
+    <ScrollArea>
+      <TabsList
+        class="text-foreground mb-3 h-auto gap-2 rounded-none border-b bg-transparent px-0 py-1"
+      >
+        <TabsTrigger
+          value="tab-1"
+          class="hover:bg-accent hover:text-foreground data-[state=active]:after:bg-primary data-[state=active]:hover:bg-accent relative after:absolute after:inset-x-0 after:bottom-0 after:-mb-1 after:h-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+        >
+          <HouseIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+          Overview
+        </TabsTrigger>
+        <TabsTrigger
+          value="tab-2"
+          class="hover:bg-accent hover:text-foreground data-[state=active]:after:bg-primary data-[state=active]:hover:bg-accent relative after:absolute after:inset-x-0 after:bottom-0 after:-mb-1 after:h-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+        >
+          <PanelsTopLeftIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+          Projects
+          <Badge class="bg-primary/15 ms-1.5 min-w-5 px-1" variant="secondary"> 3 </Badge>
+        </TabsTrigger>
+        <TabsTrigger
+          value="tab-3"
+          class="hover:bg-accent hover:text-foreground data-[state=active]:after:bg-primary data-[state=active]:hover:bg-accent relative after:absolute after:inset-x-0 after:bottom-0 after:-mb-1 after:h-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+        >
+          <BoxIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+          Packages
+          <Badge class="ms-1.5">New</Badge>
+        </TabsTrigger>
+        <TabsTrigger
+          value="tab-4"
+          class="hover:bg-accent hover:text-foreground data-[state=active]:after:bg-primary data-[state=active]:hover:bg-accent relative after:absolute after:inset-x-0 after:bottom-0 after:-mb-1 after:h-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+        >
+          <UsersRoundIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+          Team
+        </TabsTrigger>
+        <TabsTrigger
+          value="tab-5"
+          class="hover:bg-accent hover:text-foreground data-[state=active]:after:bg-primary data-[state=active]:hover:bg-accent relative after:absolute after:inset-x-0 after:bottom-0 after:-mb-1 after:h-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+        >
+          <ChartLine class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+          Insights
+        </TabsTrigger>
+        <TabsTrigger
+          value="tab-6"
+          class="hover:bg-accent hover:text-foreground data-[state=active]:after:bg-primary data-[state=active]:hover:bg-accent relative after:absolute after:inset-x-0 after:bottom-0 after:-mb-1 after:h-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+        >
+          <SettingsIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+          Settings
+        </TabsTrigger>
+      </TabsList>
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+    <TabsContent value="tab-1">
+      <p class="text-muted-foreground pt-1 text-center text-xs">Content for Tab 1</p>
+    </TabsContent>
+    <TabsContent value="tab-2">
+      <p class="text-muted-foreground pt-1 text-center text-xs">Content for Tab 2</p>
+    </TabsContent>
+    <TabsContent value="tab-3">
+      <p class="text-muted-foreground pt-1 text-center text-xs">Content for Tab 3</p>
+    </TabsContent>
+    <TabsContent value="tab-4">
+      <p class="text-muted-foreground pt-1 text-center text-xs">Content for Tab 4</p>
+    </TabsContent>
+    <TabsContent value="tab-5">
+      <p class="text-muted-foreground pt-1 text-center text-xs">Content for Tab 5</p>
+    </TabsContent>
+    <TabsContent value="tab-6">
+      <p class="text-muted-foreground pt-1 text-center text-xs">Content for Tab 6</p>
+    </TabsContent>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab13.vue
+++ b/src/components/tabs/Tab13.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+import { BoxIcon, HouseIcon, PanelsTopLeftIcon } from 'lucide-vue-next'
+</script>
+
+<template>
+  <Tabs defaultValue="tab-1" class="items-center">
+    <TabsList class="h-auto rounded-none border-b bg-transparent p-0">
+      <TabsTrigger
+        value="tab-1"
+        class="data-[state=active]:after:bg-primary relative flex-col rounded-none px-4 py-2 text-xs after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+      >
+        <HouseIcon class="mb-1.5 opacity-60" :size="16" aria-hidden="true" />
+        Overview
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-2"
+        class="data-[state=active]:after:bg-primary relative flex-col rounded-none px-4 py-2 text-xs after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+      >
+        <PanelsTopLeftIcon class="mb-1.5 opacity-60" :size="16" aria-hidden="true" />
+        Projects
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-3"
+        class="data-[state=active]:after:bg-primary relative flex-col rounded-none px-4 py-2 text-xs after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+      >
+        <BoxIcon class="mb-1.5 opacity-60" :size="16" aria-hidden="true" />
+        Packages
+      </TabsTrigger>
+    </TabsList>
+    <TabsContent value="tab-1">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 1</p>
+    </TabsContent>
+    <TabsContent value="tab-2">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 2</p>
+    </TabsContent>
+    <TabsContent value="tab-3">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 3</p>
+    </TabsContent>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab14.vue
+++ b/src/components/tabs/Tab14.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+import Badge from '@/components/ui/Badge.vue'
+</script>
+
+<template>
+  <Tabs defaultValue="tab-1">
+    <TabsList class="mx-auto flex w-full max-w-xs bg-transparent">
+      <TabsTrigger
+        value="tab-1"
+        class="group data-[state=active]:bg-muted flex-1 flex-col p-3 text-xs data-[state=active]:shadow-none"
+      >
+        <Badge
+          class="mb-1.5 min-w-5 px-1 transition-opacity group-data-[state=inactive]:opacity-50"
+        >
+          3
+        </Badge>
+        Overview
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-2"
+        class="group data-[state=active]:bg-muted flex-1 flex-col p-3 text-xs data-[state=active]:shadow-none"
+      >
+        <Badge
+          class="mb-1.5 min-w-5 px-1 transition-opacity group-data-[state=inactive]:opacity-50"
+        >
+          0
+        </Badge>
+        Projects
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-3"
+        class="group data-[state=active]:bg-muted flex-1 flex-col p-3 text-xs data-[state=active]:shadow-none"
+      >
+        <Badge
+          class="mb-1.5 min-w-5 px-1 transition-opacity group-data-[state=inactive]:opacity-50"
+        >
+          7
+        </Badge>
+        Packages
+      </TabsTrigger>
+    </TabsList>
+    <TabsContent value="tab-1">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 1</p>
+    </TabsContent>
+    <TabsContent value="tab-2">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 2</p>
+    </TabsContent>
+    <TabsContent value="tab-3">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 3</p>
+    </TabsContent>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab15.vue
+++ b/src/components/tabs/Tab15.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+import Badge from '@/components/ui/Badge.vue'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/Tooltip'
+import { BoxIcon, HouseIcon, PanelsTopLeftIcon } from 'lucide-vue-next'
+</script>
+
+<template>
+  <Tabs defaultValue="tab-1" class="items-center">
+    <TabsList>
+      <TooltipProvider :delayDuration="0">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span>
+              <TabsTrigger value="tab-1" class="py-3">
+                <HouseIcon :size="16" aria-hidden="true" />
+              </TabsTrigger>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent class="px-2 py-1 text-xs"> Overview </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <TooltipProvider :delayDuration="0">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span>
+              <TabsTrigger value="tab-2" class="group py-3">
+                <span class="relative">
+                  <PanelsTopLeftIcon :size="16" aria-hidden="true" />
+                  <Badge
+                    class="border-background absolute -top-2.5 left-full min-w-4 -translate-x-1.5 px-0.5 text-[10px]/[.875rem] transition-opacity group-data-[state=inactive]:opacity-50"
+                  >
+                    3
+                  </Badge>
+                </span>
+              </TabsTrigger>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent class="px-2 py-1 text-xs"> Projects </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <TooltipProvider :delayDuration="0">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span>
+              <TabsTrigger value="tab-3" class="py-3">
+                <BoxIcon :size="16" aria-hidden="true" />
+              </TabsTrigger>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent class="px-2 py-1 text-xs"> Packages </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </TabsList>
+    <TabsContent value="tab-1">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 1</p>
+    </TabsContent>
+    <TabsContent value="tab-2">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 2</p>
+    </TabsContent>
+    <TabsContent value="tab-3">
+      <p class="text-muted-foreground p-4 text-center text-xs">Content for Tab 3</p>
+    </TabsContent>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab16.vue
+++ b/src/components/tabs/Tab16.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+import Badge from '@/components/ui/Badge.vue'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/Tooltip'
+import { BoxIcon, HouseIcon, PanelsTopLeftIcon } from 'lucide-vue-next'
+</script>
+
+<template>
+  <Tabs defaultValue="tab-1" orientation="vertical" class="w-full flex-row">
+    <TabsList class="flex-col">
+      <TooltipProvider :delayDuration="0">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span>
+              <TabsTrigger value="tab-1" class="py-3">
+                <HouseIcon :size="16" aria-hidden="true" />
+              </TabsTrigger>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="right" class="px-2 py-1 text-xs"> Overview </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <TooltipProvider :delayDuration="0">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span>
+              <TabsTrigger value="tab-2" class="group py-3">
+                <span class="relative">
+                  <PanelsTopLeftIcon :size="16" aria-hidden="true" />
+                  <Badge
+                    class="border-background absolute -top-2.5 left-full min-w-4 -translate-x-1.5 px-0.5 text-[10px]/[.875rem] transition-opacity group-data-[state=inactive]:opacity-50"
+                  >
+                    3
+                  </Badge>
+                </span>
+              </TabsTrigger>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="right" class="px-2 py-1 text-xs"> Projects </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <TooltipProvider :delayDuration="0">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span>
+              <TabsTrigger value="tab-3" class="py-3">
+                <BoxIcon :size="16" aria-hidden="true" />
+              </TabsTrigger>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="right" class="px-2 py-1 text-xs"> Packages </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </TabsList>
+    <div class="grow rounded-md border text-start">
+      <TabsContent value="tab-1">
+        <p class="text-muted-foreground px-4 py-3 text-xs">Content for Tab 1</p>
+      </TabsContent>
+      <TabsContent value="tab-2">
+        <p class="text-muted-foreground px-4 py-3 text-xs">Content for Tab 2</p>
+      </TabsContent>
+      <TabsContent value="tab-3">
+        <p class="text-muted-foreground px-4 py-3 text-xs">Content for Tab 3</p>
+      </TabsContent>
+    </div>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab17.vue
+++ b/src/components/tabs/Tab17.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+</script>
+
+<template>
+  <Tabs defaultValue="tab-1" orientation="vertical" class="w-full flex-row">
+    <TabsList class="flex-col">
+      <TabsTrigger value="tab-1" class="w-full"> Overview </TabsTrigger>
+      <TabsTrigger value="tab-2" class="w-full"> Projects </TabsTrigger>
+      <TabsTrigger value="tab-3" class="w-full"> Packages </TabsTrigger>
+    </TabsList>
+    <div class="grow rounded-md border text-start">
+      <TabsContent value="tab-1">
+        <p class="text-muted-foreground px-4 py-3 text-xs">Content for Tab 1</p>
+      </TabsContent>
+      <TabsContent value="tab-2">
+        <p class="text-muted-foreground px-4 py-3 text-xs">Content for Tab 2</p>
+      </TabsContent>
+      <TabsContent value="tab-3">
+        <p class="text-muted-foreground px-4 py-3 text-xs">Content for Tab 3</p>
+      </TabsContent>
+    </div>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab18.vue
+++ b/src/components/tabs/Tab18.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+</script>
+
+<template>
+  <Tabs defaultValue="tab-1" orientation="vertical" class="w-full flex-row">
+    <TabsList class="flex-col rounded-none border-l bg-transparent p-0">
+      <TabsTrigger
+        value="tab-1"
+        class="data-[state=active]:after:bg-primary relative w-full justify-start rounded-none after:absolute after:inset-y-0 after:start-0 after:w-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+      >
+        Overview
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-2"
+        class="data-[state=active]:after:bg-primary relative w-full justify-start rounded-none after:absolute after:inset-y-0 after:start-0 after:w-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+      >
+        Projects
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-3"
+        class="data-[state=active]:after:bg-primary relative w-full justify-start rounded-none after:absolute after:inset-y-0 after:start-0 after:w-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+      >
+        Packages
+      </TabsTrigger>
+    </TabsList>
+    <div class="grow rounded-md border text-start">
+      <TabsContent value="tab-1">
+        <p class="text-muted-foreground px-4 py-3 text-xs">Content for Tab 1</p>
+      </TabsContent>
+      <TabsContent value="tab-2">
+        <p class="text-muted-foreground px-4 py-3 text-xs">Content for Tab 2</p>
+      </TabsContent>
+      <TabsContent value="tab-3">
+        <p class="text-muted-foreground px-4 py-3 text-xs">Content for Tab 3</p>
+      </TabsContent>
+    </div>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab19.vue
+++ b/src/components/tabs/Tab19.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+import { BoxIcon, HouseIcon, PanelsTopLeftIcon } from 'lucide-vue-next'
+</script>
+
+<template>
+  <Tabs defaultValue="tab-1" orientation="vertical" class="w-full flex-row">
+    <TabsList class="text-foreground flex-col gap-1 rounded-none bg-transparent px-1 py-0">
+      <TabsTrigger
+        value="tab-1"
+        class="hover:bg-accent hover:text-foreground data-[state=active]:after:bg-primary data-[state=active]:hover:bg-accent relative w-full justify-start after:absolute after:inset-y-0 after:start-0 after:-ms-1 after:w-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+      >
+        <HouseIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+        Overview
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-2"
+        class="hover:bg-accent hover:text-foreground data-[state=active]:after:bg-primary data-[state=active]:hover:bg-accent relative w-full justify-start after:absolute after:inset-y-0 after:start-0 after:-ms-1 after:w-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+      >
+        <PanelsTopLeftIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+        Projects
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-3"
+        class="hover:bg-accent hover:text-foreground data-[state=active]:after:bg-primary data-[state=active]:hover:bg-accent relative w-full justify-start after:absolute after:inset-y-0 after:start-0 after:-ms-1 after:w-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+      >
+        <BoxIcon class="-ms-0.5 me-1.5 opacity-60" :size="16" aria-hidden="true" />
+        Packages
+      </TabsTrigger>
+    </TabsList>
+    <div class="grow rounded-md border text-start">
+      <TabsContent value="tab-1">
+        <p class="text-muted-foreground px-4 py-3 text-xs">Content for Tab 1</p>
+      </TabsContent>
+      <TabsContent value="tab-2">
+        <p class="text-muted-foreground px-4 py-3 text-xs">Content for Tab 2</p>
+      </TabsContent>
+      <TabsContent value="tab-3">
+        <p class="text-muted-foreground px-4 py-3 text-xs">Content for Tab 3</p>
+      </TabsContent>
+    </div>
+  </Tabs>
+</template>

--- a/src/components/tabs/Tab20.vue
+++ b/src/components/tabs/Tab20.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs'
+</script>
+
+<template>
+  <Tabs defaultValue="tab-1" orientation="vertical" class="w-full flex-row">
+    <TabsList class="flex-col gap-1 bg-transparent py-0">
+      <TabsTrigger
+        value="tab-1"
+        class="data-[state=active]:bg-muted w-full justify-start data-[state=active]:shadow-none"
+      >
+        Overview
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-2"
+        class="data-[state=active]:bg-muted w-full justify-start data-[state=active]:shadow-none"
+      >
+        Projects
+      </TabsTrigger>
+      <TabsTrigger
+        value="tab-3"
+        class="data-[state=active]:bg-muted w-full justify-start data-[state=active]:shadow-none"
+      >
+        Packages
+      </TabsTrigger>
+    </TabsList>
+    <div class="grow rounded-md border text-start">
+      <TabsContent value="tab-1">
+        <p class="text-muted-foreground px-4 py-3 text-xs">Content for Tab 1</p>
+      </TabsContent>
+      <TabsContent value="tab-2">
+        <p class="text-muted-foreground px-4 py-3 text-xs">Content for Tab 2</p>
+      </TabsContent>
+      <TabsContent value="tab-3">
+        <p class="text-muted-foreground px-4 py-3 text-xs">Content for Tab 3</p>
+      </TabsContent>
+    </div>
+  </Tabs>
+</template>

--- a/src/components/ui/Tabs/Tabs.vue
+++ b/src/components/ui/Tabs/Tabs.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils'
+import type { TabsRootEmits, TabsRootProps } from 'reka-ui'
+import { TabsRoot, useForwardPropsEmits } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+
+const emits = defineEmits<TabsRootEmits>()
+const props = defineProps<TabsRootProps & { class?: HTMLAttributes['class'] }>()
+
+const forwarded = useForwardPropsEmits(props, emits)
+</script>
+
+<template>
+  <TabsRoot v-bind="forwarded" :class="cn('flex flex-col gap-2', props.class)">
+    <slot />
+  </TabsRoot>
+</template>

--- a/src/components/ui/Tabs/TabsContent.vue
+++ b/src/components/ui/Tabs/TabsContent.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { TabsContent, type TabsContentProps } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<TabsContentProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+</script>
+
+<template>
+  <TabsContent :class="cn('flex-1 outline-none', props.class)" v-bind="delegatedProps">
+    <slot />
+  </TabsContent>
+</template>

--- a/src/components/ui/Tabs/TabsList.vue
+++ b/src/components/ui/Tabs/TabsList.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { TabsList, type TabsListProps } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<TabsListProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+</script>
+
+<template>
+  <TabsList
+    v-bind="delegatedProps"
+    :class="
+      cn(
+        'bg-muted text-muted-foreground/70 inline-flex w-fit items-center justify-center rounded-md p-0.5',
+        props.class
+      )
+    "
+  >
+    <slot />
+  </TabsList>
+</template>

--- a/src/components/ui/Tabs/TabsTrigger.vue
+++ b/src/components/ui/Tabs/TabsTrigger.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { TabsTrigger, type TabsTriggerProps, useForwardProps } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<TabsTriggerProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <TabsTrigger
+    v-bind="forwardedProps"
+    :class="
+      cn(
+        'hover:text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 inline-flex items-center justify-center rounded-sm px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-xs [&_svg]:shrink-0',
+        props.class
+      )
+    "
+  >
+    <slot />
+  </TabsTrigger>
+</template>

--- a/src/components/ui/Tabs/index.ts
+++ b/src/components/ui/Tabs/index.ts
@@ -1,0 +1,4 @@
+export { default as Tabs } from './Tabs.vue'
+export { default as TabsContent } from './TabsContent.vue'
+export { default as TabsList } from './TabsList.vue'
+export { default as TabsTrigger } from './TabsTrigger.vue'

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -74,6 +74,12 @@ const router = createRouter({
       name: 'tooltips',
       component: () => import('@/views/Tooltips.vue'),
       meta: { title: 'originui-vue/tooltips' }
+    },
+    {
+      path: '/tabs',
+      name: 'tabs',
+      component: () => import('@/views/Tabs.vue'),
+      meta: { title: 'originui-vue/tabs' }
     }
   ]
 })

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -76,6 +76,7 @@ const availableComponents = [
   { name: 'Dialogs', path: '/dialogs' },
   { name: 'Accordion', path: '/accordions' },
   { name: 'Tooltip', path: '/tooltips' },
+  { name: 'Tabs', path: '/tabs' },
   { name: 'Dropdown and Popover', path: '#' }
 ]
 

--- a/src/views/Tabs.vue
+++ b/src/views/Tabs.vue
@@ -1,0 +1,60 @@
+<template>
+  <main>
+    <div class="px-4 sm:px-6">
+      <div ref="containerRef" class="mx-auto w-full max-w-6xl">
+        <PageHeader
+          title="Tabs Components - Origin UI"
+          heading="Tabs"
+          description="A growing collection of 20 tabs components built with React and Tailwind CSS."
+        >
+          A growing collection of {{ totalComponents }} tabs components built with
+          <span class="text-vue">Vue</span> and TailwindCSS.
+        </PageHeader>
+
+        <div
+          class="-m-px grid grid-cols-12 *:px-1 *:py-12 *:not-first:-ms-px *:not-first:-mt-px sm:*:px-8 xl:*:px-12 overflow-hidden *:before:absolute *:before:bg-border/70 *:before:[block-size:100vh] *:before:[inline-size:1px] *:before:[inset-block-start:0] *:before:[inset-inline-start:-1px] *:after:absolute *:after:bg-border/70 *:after:[block-size:1px] *:after:[inline-size:100vw] *:after:[inset-block-start:-1px] *:after:[inset-inline-start:0]"
+        >
+          <DemoComponent
+            v-for="component in tabsFiles"
+            :key="component"
+            class="group/item relative col-span-12 sm:col-span-6 lg:col-span-6 text-center"
+            :directory="tabsDirectory"
+            :componentName="component"
+          />
+        </div>
+      </div>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import DemoComponent from '@/demo/DemoComponent.vue'
+import PageHeader from '@/demo/PageHeader.vue'
+import { computed, ref } from 'vue'
+
+const tabsFiles = ref([
+  'Tab01',
+  'Tab02',
+  'Tab03',
+  'Tab04',
+  'Tab05',
+  'Tab06',
+  'Tab07',
+  'Tab08',
+  'Tab09',
+  'Tab10',
+  'Tab11',
+  'Tab12',
+  'Tab13',
+  'Tab14',
+  'Tab15',
+  'Tab16',
+  'Tab17',
+  'Tab18',
+  'Tab19',
+  'Tab20'
+])
+const tabsDirectory = 'tabs'
+
+const totalComponents = computed(() => tabsFiles.value.length)
+</script>


### PR DESCRIPTION
Adds 20 reusable Tabs components to the origin-vue project, implemented in Vue 3 with shadcn-vue.
Includes support for icons (lucide-vue-next), badges, horizontal scroll, centered alignment, and multiple layout variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a comprehensive Tabs component suite, featuring 20 unique tab interface demos with various layouts, icons, badges, tooltips, and scrollable options.
  * Added a dedicated Tabs page showcasing all tab variations, accessible via the main navigation.
  * Enhanced home page navigation with a new entry linking to the Tabs component collection.

* **Navigation**
  * Added a new route for the Tabs page for easier access and discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->